### PR TITLE
Feature/block shift and gem gating

### DIFF
--- a/app/Http/Controllers/UserCaasController.php
+++ b/app/Http/Controllers/UserCaasController.php
@@ -9,6 +9,7 @@ use App\Models\Caas;
 use App\Models\Role;
 use App\Models\Stage;
 use App\Models\User;
+use App\Models\Configuration;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -171,7 +172,7 @@ class UserCaasController extends Controller
         if (isset($validated['gems']) && strtolower($validated['gems']) === 'no gem') {
             $caas->role_id = null;
             $caas->save();
-        } 
+        }
         // Jika admin memasukkan nama gem, kita cari/buat role di DB
         elseif (!empty($validated['gems'])) {
             $role = Role::firstOrCreate(['name' => $validated['gems']]);
@@ -231,6 +232,14 @@ class UserCaasController extends Controller
 
         // Cek apakah user sudah punya record Caas
         $caas = Caas::where('user_id', $user->id)->first();
+
+
+        $config = Configuration::find(1);
+        // Block jika fitur Choose Gems OFF
+        if (! $config->role_on) {
+            return redirect()->route('caas.home')
+                ->with('error', 'Pemilihan gems belum dibuka oleh admin.');
+        }
 
         // Jika user sudah memilih gem, langsung redirect ke fixGemView
         if ($caas && $caas->role_id) {

--- a/resources/views/CaAs/ChooseShift.blade.php
+++ b/resources/views/CaAs/ChooseShift.blade.php
@@ -130,7 +130,7 @@
                         <tr class="h-10 lg:h-12 md:h-12">
                             <th class="border-[1px] border-black">No.</th>
                             <th class="border-[1px] border-black">Date</th>
-                            <th class="border-[1px] border-black">Shift No.</th>
+                            <th class="border-[1px] border-black">Shift</th>
                             <th class="border-[1px] border-black">Time</th>
                             <th class="border-[1px] border-black">Quota</th>
                             <th class="border-[1px] border-black">Action</th>

--- a/resources/views/CaAs/FixShift.blade.php
+++ b/resources/views/CaAs/FixShift.blade.php
@@ -46,6 +46,7 @@
 
                     <p class="ml-3 text-lg font-crimson-text font-bold">Date: {{ Carbon\Carbon::parse($shift->date)->format('l, j F Y') }}</p>
                     <p class="ml-3 text-lg font-crimson-text font-bold">Time: {{ substr($shift->time_start, 0, 5) . '-' . substr($shift->time_end, 0, 5) . ' WIB' }}</p>
+                    <p class="ml-3 text-lg font-crimson-text font-bold">Shift: {{ $shift->shift_no }}</p>
 
                     <p class="lg:text-lg text-base mt-5 font-im-fell-english">Please make sure to remember your assigned shift and stay updated via our OA Line for any upcoming information.</p>
                     <p class="lg:text-lg text-base mt-5 font-im-fell-english"> Thank you!</p>


### PR DESCRIPTION
## Summary  
This PR introduces configuration-driven gating and UI enhancements for shift and gem selection:

1. **Configuration gating**  
   - Blocks access to `/choose-shift` when `isi_jadwal_on` is false.  
   - Blocks access to `/choose-gem` when `role_on` is false.  
   - Prevents users from bypassing via direct URLs.  

2. **Fix-Shift view enhancements**  
   - Displays **Shift Number** (`shift_no`) alongside formatted **Date** and **Time** (`HH:MM–HH:MM WIB`).

---
Please review these changes to ensure CAAS users cannot select shifts or gems until the admin enables them, and that the assigned shift details render as expected.  
